### PR TITLE
Form select populating

### DIFF
--- a/client/apis/parses.ts
+++ b/client/apis/parses.ts
@@ -23,9 +23,8 @@ export async function getCharacterData(character: {
   return data
 }
 
-export async function getEncounterDetails(): Promise<Encounter> {
+export async function getEncounterDetails(): Promise<Encounter[]> {
   const { body } = await request.get(`${rootUrl}/encounters`).then((res) => res)
-  console.log(body)
   return body
 }
 

--- a/client/apis/parses.ts
+++ b/client/apis/parses.ts
@@ -1,6 +1,6 @@
 import request from 'superagent'
 import type { ParseData } from '../../models/filteredParseData.ts'
-import type { CharacterData } from '../../models/character.ts'
+import type { Encounter } from '../../models/encounterData.ts'
 
 const rootUrl = '/api/v1/getData'
 
@@ -23,8 +23,16 @@ export async function getCharacterData(character: {
   return data
 }
 
-export async function getEncounterDetails(): Promise<ParseData> {
-  const { data } = await request.get(rootUrl).then((res) => res.body)
+export async function getEncounterDetails(): Promise<Encounter> {
+  const { body } = await request.get(`${rootUrl}/encounters`).then((res) => res)
+  console.log(body)
+  return body
+}
+
+/* export async function getServerSlugs(): Promise<ServerSlugs> {
+  const { data } = await request
+    .get(`${rootUrl}/serverSlugs`)
+    .then((res) => res.body)
   console.log(data)
   return data
-}
+} */

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -44,7 +44,6 @@ function App() {
 
   return (
     <>
-      <EncounterSelectOptions />
       <div className="centered">
         <form onSubmit={onClick}>
           <div className="form-container">
@@ -87,14 +86,25 @@ function App() {
                 onChange={(e) => setServerRegion(e.target.value)}
               />
             </div>
-            <div className="form-field">
-              <label htmlFor="serverRegion">EncounterId: </label>
+            {/*  <div className="form-field">
+              <label htmlFor="encounterId">EncounterId: </label>
               <input
                 id="encounterId"
                 type="text"
                 name="encounterId"
                 onChange={(e) => setEncounterId(Number(e.target.value))}
               />
+            </div> */}
+            <div className="form-field">
+              <label htmlFor="encounterId">EncounterId: </label>
+              <select
+                id="encounterId"
+                name="encounterId"
+                value={encounterId}
+                onChange={(e) => setServerSlug(e.target.value)}
+              >
+                <EncounterSelectOptions />
+              </select>
             </div>
           </div>
           <div className="form-button">

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useParses } from '../hooks/useParses'
 import ParseList from './ParseList'
+import EncounterSelectOptions from './EncounterSelectOptions'
 
 // NOTE: the encounterId MUST be from the current raid tier or it cant find results
 // old raid tiers just time out because the data is not stored anymore
@@ -43,6 +44,7 @@ function App() {
 
   return (
     <>
+      <EncounterSelectOptions />
       <div className="centered">
         <form onSubmit={onClick}>
           <div className="form-container">
@@ -55,7 +57,7 @@ function App() {
                 onChange={(e) => setName(e.target.value)}
               />
             </div>
-            <div className="form-field">
+            {/* <div className="form-field">
               <label htmlFor="serverSlug">Server: </label>
               <select
                 id="serverSlug"
@@ -66,8 +68,8 @@ function App() {
                 <option value="frostmourne">frostmourne</option>
                 <option value="frne">Frourne</option>
               </select>
-            </div>
-            {/* <div className="form-field">
+            </div> */}
+            <div className="form-field">
               <label htmlFor="serverSlug">Server: </label>
               <input
                 id="serverSlug"
@@ -75,7 +77,7 @@ function App() {
                 name="name"
                 onChange={(e) => setServerSlug(e.target.value)}
               />
-            </div> */}
+            </div>
             <div className="form-field">
               <label htmlFor="serverRegion">Region: </label>
               <input

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -38,15 +38,6 @@ function App() {
   const handleCallback = useCallback((firstEncounterId: number) => {
     setEncounterId(firstEncounterId)
   }, [])
-  {
-    /* <select
-                id="serverSlug"
-                name="serverSlug"
-                onChange={(e) => setServerSlug(e.target.value)}
-              >
-                <option value="frostmourne">Volvo</option>
-              </select> */
-  }
 
   const { data, isLoading, isError, fetchStatus } = useParses(character)
 
@@ -64,18 +55,6 @@ function App() {
                 onChange={(e) => setName(e.target.value)}
               />
             </div>
-            {/* <div className="form-field">
-              <label htmlFor="serverSlug">Server: </label>
-              <select
-                id="serverSlug"
-                name="serverSlug"
-                value={serverSlug}
-                onChange={(e) => setServerSlug(e.target.value)}
-              >
-                <option value="frostmourne">frostmourne</option>
-                <option value="frne">Frourne</option>
-              </select>
-            </div> */}
             <div className="form-field">
               <label htmlFor="serverSlug">Server: </label>
               <input
@@ -87,15 +66,6 @@ function App() {
                 }
               />
             </div>
-            {/* <div className="form-field">
-              <label htmlFor="serverRegion">Region: </label>
-              <input
-                id="serverRegion"
-                type="text"
-                name="serverRegion"
-                onChange={(e) => setServerRegion(e.target.value)}
-              />
-            </div> */}
             <div className="form-field">
               <label htmlFor="serverRegion">Region: </label>
               <select
@@ -111,15 +81,6 @@ function App() {
                 <option value="CN">China</option>
               </select>
             </div>
-            {/*  <div className="form-field">
-              <label htmlFor="encounterId">EncounterId: </label>
-              <input
-                id="encounterId"
-                type="text"
-                name="encounterId"
-                onChange={(e) => setEncounterId(Number(e.target.value))}
-              />
-            </div> */}
             <div className="form-field">
               <label htmlFor="encounterId">Encounter: </label>
               <select

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -2,6 +2,9 @@ import { useState } from 'react'
 import { useParses } from '../hooks/useParses'
 import ParseList from './ParseList'
 
+// NOTE: the encounterId MUST be from the current raid tier or it cant find results
+// old raid tiers just time out because the data is not stored anymore
+
 function App() {
   const [name, setName] = useState('')
   const [serverSlug, setServerSlug] = useState('')
@@ -52,7 +55,7 @@ function App() {
                 onChange={(e) => setName(e.target.value)}
               />
             </div>
-            {/* <div className="form-field">
+            <div className="form-field">
               <label htmlFor="serverSlug">Server: </label>
               <select
                 id="serverSlug"
@@ -63,8 +66,8 @@ function App() {
                 <option value="frostmourne">frostmourne</option>
                 <option value="frne">Frourne</option>
               </select>
-            </div> */}
-            <div className="form-field">
+            </div>
+            {/* <div className="form-field">
               <label htmlFor="serverSlug">Server: </label>
               <input
                 id="serverSlug"
@@ -72,7 +75,7 @@ function App() {
                 name="name"
                 onChange={(e) => setServerSlug(e.target.value)}
               />
-            </div>
+            </div> */}
             <div className="form-field">
               <label htmlFor="serverRegion">Region: </label>
               <input

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -56,7 +56,7 @@ function App() {
                 onChange={(e) => setName(e.target.value)}
               />
             </div>
-            <div className="form-field selector">
+            <div className="form-field">
               <label htmlFor="encounterId">Encounter: </label>
               <select
                 id="encounterId"
@@ -67,7 +67,7 @@ function App() {
                 <EncounterSelectOptions handleCallback={handleCallback} />
               </select>
             </div>
-            <div className="form-field selector">
+            <div className="form-field">
               <label htmlFor="serverRegion">Region: </label>
               <select
                 id="serverRegion"

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -5,11 +5,12 @@ import EncounterSelectOptions from './EncounterSelectOptions'
 
 // NOTE: the encounterId MUST be from the current raid tier or it cant find results
 // old raid tiers just time out because the data is not stored anymore
+// using US as default because it's the first value to select
 
 function App() {
   const [name, setName] = useState('')
   const [serverSlug, setServerSlug] = useState('')
-  const [serverRegion, setServerRegion] = useState('')
+  const [serverRegion, setServerRegion] = useState('US')
   const [encounterId, setEncounterId] = useState(0)
 
   const [character, setCharacter] = useState({
@@ -86,7 +87,7 @@ function App() {
                 }
               />
             </div>
-            <div className="form-field">
+            {/* <div className="form-field">
               <label htmlFor="serverRegion">Region: </label>
               <input
                 id="serverRegion"
@@ -94,6 +95,21 @@ function App() {
                 name="serverRegion"
                 onChange={(e) => setServerRegion(e.target.value)}
               />
+            </div> */}
+            <div className="form-field">
+              <label htmlFor="serverRegion">Region: </label>
+              <select
+                id="serverRegion"
+                name="serverRegion"
+                value={serverRegion}
+                onChange={(e) => setServerRegion(e.target.value)}
+              >
+                <option value="US">United States - OCE</option>
+                <option value="EU">Europe</option>
+                <option value="KR">Korea</option>
+                <option value="TW">Taiwan</option>
+                <option value="CN">China</option>
+              </select>
             </div>
             {/*  <div className="form-field">
               <label htmlFor="encounterId">EncounterId: </label>
@@ -105,7 +121,7 @@ function App() {
               />
             </div> */}
             <div className="form-field">
-              <label htmlFor="encounterId">EncounterId: </label>
+              <label htmlFor="encounterId">Encounter: </label>
               <select
                 id="encounterId"
                 name="encounterId"

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -26,6 +26,16 @@ function App() {
     })
   }
 
+  {
+    /* <select
+                id="serverSlug"
+                name="serverSlug"
+                onChange={(e) => setServerSlug(e.target.value)}
+              >
+                <option value="frostmourne">Volvo</option>
+              </select> */
+  }
+
   const { data, isLoading, isError, fetchStatus } = useParses(character)
 
   return (
@@ -44,13 +54,25 @@ function App() {
             </div>
             <div className="form-field">
               <label htmlFor="serverSlug">Server: </label>
+              <select
+                id="serverSlug"
+                name="serverSlug"
+                value={serverSlug}
+                onChange={(e) => setServerSlug(e.target.value)}
+              >
+                <option value="frostmourne">frostmourne</option>
+                <option value="frne">Frourne</option>
+              </select>
+            </div>
+            {/* <div className="form-field">
+              <label htmlFor="serverSlug">Server: </label>
               <input
                 id="serverSlug"
                 type="text"
-                name="serverSlug"
+                name="name"
                 onChange={(e) => setServerSlug(e.target.value)}
               />
-            </div>
+            </div> */}
             <div className="form-field">
               <label htmlFor="serverRegion">Region: </label>
               <input

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -101,7 +101,7 @@ function App() {
                 id="encounterId"
                 name="encounterId"
                 value={encounterId}
-                onChange={(e) => setServerSlug(e.target.value)}
+                onChange={(e) => setEncounterId(Number(e.target.value))}
               >
                 <EncounterSelectOptions />
               </select>
@@ -120,6 +120,9 @@ function App() {
             <p className="search-status">Please Add Your Character Details!</p>
           ) : !data || isLoading ? (
             <p className="search-status">Loading...</p>
+          ) : data?.worldData?.encounter?.characterRankings?.rankings.length ===
+            0 ? (
+            <p className="search-status">No parses found for your time.</p>
           ) : (
             data?.worldData?.encounter?.characterRankings?.rankings?.map(
               (ranking) => (

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -56,7 +56,7 @@ function App() {
                 onChange={(e) => setName(e.target.value)}
               />
             </div>
-            <div className="form-field">
+            <div className="form-field selector">
               <label htmlFor="encounterId">Encounter: </label>
               <select
                 id="encounterId"
@@ -67,7 +67,7 @@ function App() {
                 <EncounterSelectOptions handleCallback={handleCallback} />
               </select>
             </div>
-            <div className="form-field">
+            <div className="form-field selector">
               <label htmlFor="serverRegion">Region: </label>
               <select
                 id="serverRegion"

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -56,15 +56,15 @@ function App() {
               />
             </div>
             <div className="form-field">
-              <label htmlFor="serverSlug">Server: </label>
-              <input
-                id="serverSlug"
-                type="text"
-                name="name"
-                onChange={(e) =>
-                  setServerSlug(sanitiseServerSlug(e.target.value))
-                }
-              />
+              <label htmlFor="encounterId">Encounter: </label>
+              <select
+                id="encounterId"
+                name="encounterId"
+                value={encounterId}
+                onChange={(e) => setEncounterId(Number(e.target.value))}
+              >
+                <EncounterSelectOptions handleCallback={handleCallback} />
+              </select>
             </div>
             <div className="form-field">
               <label htmlFor="serverRegion">Region: </label>
@@ -82,15 +82,15 @@ function App() {
               </select>
             </div>
             <div className="form-field">
-              <label htmlFor="encounterId">Encounter: </label>
-              <select
-                id="encounterId"
-                name="encounterId"
-                value={encounterId}
-                onChange={(e) => setEncounterId(Number(e.target.value))}
-              >
-                <EncounterSelectOptions handleCallback={handleCallback} />
-              </select>
+              <label htmlFor="serverSlug">Server: </label>
+              <input
+                id="serverSlug"
+                type="text"
+                name="name"
+                onChange={(e) =>
+                  setServerSlug(sanitiseServerSlug(e.target.value))
+                }
+              />
             </div>
           </div>
           <div className="form-button">

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -52,7 +52,7 @@ function App() {
                 onChange={(e) => setName(e.target.value)}
               />
             </div>
-            <div className="form-field">
+            {/* <div className="form-field">
               <label htmlFor="serverSlug">Server: </label>
               <select
                 id="serverSlug"
@@ -63,8 +63,8 @@ function App() {
                 <option value="frostmourne">frostmourne</option>
                 <option value="frne">Frourne</option>
               </select>
-            </div>
-            {/* <div className="form-field">
+            </div> */}
+            <div className="form-field">
               <label htmlFor="serverSlug">Server: </label>
               <input
                 id="serverSlug"
@@ -72,7 +72,7 @@ function App() {
                 name="name"
                 onChange={(e) => setServerSlug(e.target.value)}
               />
-            </div> */}
+            </div>
             <div className="form-field">
               <label htmlFor="serverRegion">Region: </label>
               <input
@@ -101,7 +101,7 @@ function App() {
             <p className="search-status">
               Couldn&apos;t find that character...
             </p>
-          ) : fetchStatus === 'idle' ? (
+          ) : fetchStatus === 'idle' && !data ? (
             <p className="search-status">Please Add Your Character Details!</p>
           ) : !data || isLoading ? (
             <p className="search-status">Loading...</p>

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -40,6 +40,7 @@ function App() {
   }, [])
 
   const { data, isLoading, isError, fetchStatus } = useParses(character)
+  console.log(0)
 
   return (
     <>

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useParses } from '../hooks/useParses'
 import ParseList from './ParseList'
 import EncounterSelectOptions from './EncounterSelectOptions'
@@ -30,6 +30,13 @@ function App() {
     })
   }
 
+  function sanitiseServerSlug(serverSlug: string) {
+    return serverSlug.replace(/\s+/g, '-').replace(/'/g, '').toLowerCase()
+  }
+
+  const handleCallback = useCallback((firstEncounterId: number) => {
+    setEncounterId(firstEncounterId)
+  }, [])
   {
     /* <select
                 id="serverSlug"
@@ -74,7 +81,9 @@ function App() {
                 id="serverSlug"
                 type="text"
                 name="name"
-                onChange={(e) => setServerSlug(e.target.value)}
+                onChange={(e) =>
+                  setServerSlug(sanitiseServerSlug(e.target.value))
+                }
               />
             </div>
             <div className="form-field">
@@ -103,7 +112,7 @@ function App() {
                 value={encounterId}
                 onChange={(e) => setEncounterId(Number(e.target.value))}
               >
-                <EncounterSelectOptions />
+                <EncounterSelectOptions handleCallback={handleCallback} />
               </select>
             </div>
           </div>

--- a/client/components/EncounterSelectOptions.tsx
+++ b/client/components/EncounterSelectOptions.tsx
@@ -3,8 +3,8 @@ import { useEncounterIds } from '../hooks/useParses'
 
 const EncounterSelectOptions = () => {
   const { data, isLoading, isError, fetchStatus } = useEncounterIds()
-  if (isLoading) return <p>Loading...</p>
-  if (isError) return <p>Error...</p>
+  if (isLoading) return <option>Loading</option>
+  if (isError) return <option>Error</option>
   return (
     <>
       {data[0].encounters.map((encounter, index) => (

--- a/client/components/EncounterSelectOptions.tsx
+++ b/client/components/EncounterSelectOptions.tsx
@@ -7,34 +7,31 @@ const EncounterSelectOptions = ({
   handleCallback: (id: number) => void
 }) => {
   const { data, isLoading, isError } = useEncounterIds()
-
   const [isInitialized, setIsInitialized] = useState(false)
 
   useEffect(() => {
-    if (
-      !isLoading &&
-      !isError &&
-      data &&
-      data[2] &&
-      data[2].encounters.length > 0
-    ) {
-      handleCallback(data[2].encounters[0].id)
+    if (!isLoading && !isError && data) {
+      handleCallback(data[0].id)
       setIsInitialized(true)
     }
   }, [data, isLoading, isError, isInitialized]) // eslint-disable-line
   if (isLoading) return <option>Loading</option>
   if (isError) return <option>Error</option>
+  console.log(data)
   return (
     <>
-      {data[2].encounters.map(
-        (encounter: { id: number; name: string }, index: number) => (
-          <option key={index} value={encounter.id}>
-            {encounter.name}
-          </option>
-        )
-      )}
+      {data.map((data: { id: number; name: string }, index: number) => (
+        <option key={index} value={data.id}>
+          {data.name}
+        </option>
+      ))}
     </>
   )
 }
 
 export default EncounterSelectOptions
+
+// NOTE* We are intentionally not includeing handleCallback in the
+// dependency array for useEffect, we are doing this because we
+// only want to call handleCallback once, when the data is loaded
+// becuase we want a reactive default state in the parent component

--- a/client/components/EncounterSelectOptions.tsx
+++ b/client/components/EncounterSelectOptions.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const ParseList = () => {
+  return (
+    <>
+      <option value="frostmourne">frostmourne</option>
+    </>
+  )
+}
+
+export default ParseList

--- a/client/components/EncounterSelectOptions.tsx
+++ b/client/components/EncounterSelectOptions.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useEncounterIds } from '../hooks/useParses'
 
 const EncounterSelectOptions = ({

--- a/client/components/EncounterSelectOptions.tsx
+++ b/client/components/EncounterSelectOptions.tsx
@@ -7,7 +7,7 @@ const EncounterSelectOptions = () => {
   if (isError) return <p>Error...</p>
   return (
     <>
-      <p>{data[0].name}</p>
+      <p>{data.at(1).name}</p>
     </>
   )
 }

--- a/client/components/EncounterSelectOptions.tsx
+++ b/client/components/EncounterSelectOptions.tsx
@@ -1,17 +1,38 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useEncounterIds } from '../hooks/useParses'
 
-const EncounterSelectOptions = () => {
-  const { data, isLoading, isError, fetchStatus } = useEncounterIds()
+const EncounterSelectOptions = ({
+  handleCallback,
+}: {
+  handleCallback: (id: number) => void
+}) => {
+  const { data, isLoading, isError } = useEncounterIds()
+
+  const [isInitialized, setIsInitialized] = useState(false)
+
+  useEffect(() => {
+    if (
+      !isLoading &&
+      !isError &&
+      data &&
+      data[2] &&
+      data[2].encounters.length > 0
+    ) {
+      handleCallback(data[2].encounters[0].id)
+      setIsInitialized(true)
+    }
+  }, [data, isLoading, isError, isInitialized]) // eslint-disable-line
   if (isLoading) return <option>Loading</option>
   if (isError) return <option>Error</option>
   return (
     <>
-      {data[2].encounters.map((encounter, index) => (
-        <option key={index} value={encounter.id}>
-          {encounter.name}
-        </option>
-      ))}
+      {data[2].encounters.map(
+        (encounter: { id: number; name: string }, index: number) => (
+          <option key={index} value={encounter.id}>
+            {encounter.name}
+          </option>
+        )
+      )}
     </>
   )
 }

--- a/client/components/EncounterSelectOptions.tsx
+++ b/client/components/EncounterSelectOptions.tsx
@@ -1,11 +1,15 @@
 import React from 'react'
+import { useEncounterIds } from '../hooks/useParses'
 
-const ParseList = () => {
+const EncounterSelectOptions = () => {
+  const { data, isLoading, isError, fetchStatus } = useEncounterIds()
+  if (isLoading) return <p>Loading...</p>
+  if (isError) return <p>Error...</p>
   return (
     <>
-      <option value="frostmourne">frostmourne</option>
+      <p>{data[0].name}</p>
     </>
   )
 }
 
-export default ParseList
+export default EncounterSelectOptions

--- a/client/components/EncounterSelectOptions.tsx
+++ b/client/components/EncounterSelectOptions.tsx
@@ -7,7 +7,11 @@ const EncounterSelectOptions = () => {
   if (isError) return <p>Error...</p>
   return (
     <>
-      <p>{data.at(1).name}</p>
+      {data[0].encounters.map((encounter, index) => (
+        <option key={index} value={encounter.id}>
+          {encounter.name}
+        </option>
+      ))}
     </>
   )
 }

--- a/client/components/EncounterSelectOptions.tsx
+++ b/client/components/EncounterSelectOptions.tsx
@@ -7,7 +7,7 @@ const EncounterSelectOptions = () => {
   if (isError) return <option>Error</option>
   return (
     <>
-      {data[0].encounters.map((encounter, index) => (
+      {data[2].encounters.map((encounter, index) => (
         <option key={index} value={encounter.id}>
           {encounter.name}
         </option>

--- a/client/components/ServerSlugSelectOptions.tsx
+++ b/client/components/ServerSlugSelectOptions.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const ParseList = () => {
+  return (
+    <>
+      <option value="frostmourne">frostmourne</option>
+    </>
+  )
+}
+
+export default ParseList

--- a/client/hooks/useParses.ts
+++ b/client/hooks/useParses.ts
@@ -22,6 +22,8 @@ export function useParses(character: {
     queryKey: ['parses', character],
     queryFn: () => getCharacterData(character),
     enabled: characterValid,
+    staleTime: Infinity,
+    cacheTime: Infinity,
   })
   return { ...query }
 }
@@ -30,6 +32,8 @@ export function useEncounterIds() {
   const query = useQuery({
     queryKey: ['encounterDetails'],
     queryFn: () => getEncounterDetails(),
+    staleTime: Infinity,
+    cacheTime: Infinity,
   })
   return { ...query }
 }

--- a/client/hooks/useParses.ts
+++ b/client/hooks/useParses.ts
@@ -1,5 +1,9 @@
 import { useQuery } from '@tanstack/react-query'
-import { getCharacterData } from '../apis/parses'
+import {
+  getCharacterData,
+  getEncounterDetails,
+  /* getServerSlugs, */
+} from '../apis/parses'
 
 export function useParses(character: {
   name: string
@@ -21,3 +25,19 @@ export function useParses(character: {
   })
   return { ...query }
 }
+
+export function useEncounterIds() {
+  const query = useQuery({
+    queryKey: ['encounterDetails'],
+    queryFn: () => getEncounterDetails(),
+  })
+  return { ...query }
+}
+
+/* export function useServerSlugs() {
+  const query = useQuery({
+    queryKey: ['serverSlugs'],
+    queryFn: () => getServerSlugs(),
+  })
+  return { ...query }
+} */

--- a/client/styles/index.css
+++ b/client/styles/index.css
@@ -6,6 +6,13 @@ label {
   display: block;
 }
 
+select {
+  display: block;
+  width: 10.938rem;
+
+  border: 1px solid #000000;
+}
+
 .centered {
   padding: 0;
   background-color: #ffffff;

--- a/client/styles/index.css
+++ b/client/styles/index.css
@@ -9,7 +9,6 @@ label {
 select {
   display: block;
   width: 10.938rem;
-
   border: 1px solid #000000;
 }
 

--- a/client/styles/index.css
+++ b/client/styles/index.css
@@ -1,3 +1,7 @@
+/* TODO: create a custom 
+select dropdown because native 
+select dropdowns arent stylable */
+
 input {
   display: block;
   border: 1px solid #000000;

--- a/models/encounterData.ts
+++ b/models/encounterData.ts
@@ -1,5 +1,4 @@
 export interface EncounterData {
-  name: string
   encounters: Encounter[]
 }
 

--- a/models/encounterData.ts
+++ b/models/encounterData.ts
@@ -1,7 +1,3 @@
-export interface EncounterData {
-  encounters: Encounter[]
-}
-
 export interface Encounter {
   name: string
   id: number

--- a/models/encounterData.ts
+++ b/models/encounterData.ts
@@ -1,0 +1,9 @@
+export interface EncounterData {
+  name: string
+  encounters: Encounter[]
+}
+
+export interface Encounter {
+  name: string
+  id: number
+}

--- a/server/routes/getData.ts
+++ b/server/routes/getData.ts
@@ -191,6 +191,7 @@ router.get('/encounters', async (req, res) => {
       body: JSON.stringify({ Query }),
     })
 
+    console.log(encounters)
     const jsonEncounters = await encounters.json()
 
     const raidOnlyEncounters =

--- a/server/routes/getData.ts
+++ b/server/routes/getData.ts
@@ -193,9 +193,14 @@ router.get('/encounters', async (req, res) => {
 
     const jsonEncounters = await encounters.json()
 
-    console.log(jsonEncounters)
+    const raidOnlyEncounters =
+      await jsonEncounters.data.worldData.expansion.zones.filter(
+        (zone: { name: string | string[] }) =>
+          !zone.name.includes('Mythic+') && !zone.name.includes('zone-')
+      )
+    console.log(raidOnlyEncounters)
 
-    res.json(jsonEncounters)
+    res.json(raidOnlyEncounters)
   } catch (error) {
     console.log(error)
     res.status(500).json({ message: 'Something went wrong' })

--- a/server/routes/getData.ts
+++ b/server/routes/getData.ts
@@ -74,14 +74,14 @@ router.get('/', async (req, res) => {
       queryParams.serverRegion
     )
 
-    const response = await fetch(apiUrl, {
+    /* const response = await fetch(apiUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({ Query }),
-    })
+    }) */
 
     Query = queryCharacterParses(
       queryParams.name,

--- a/server/routes/getData.ts
+++ b/server/routes/getData.ts
@@ -2,11 +2,9 @@ import express from 'express'
 import dotenv from 'dotenv'
 import { getToken, updateToken } from '../db/functions/token'
 import {
-  queryExpansionIDs,
   queryEncounterIDs,
   queryClassesAndSpecs,
   queryParsesBySpecAndDuration,
-  queryRegionAndServer,
   queryCharacterParses,
   queryCharacterDetailsTEST,
 } from './queries/queries'
@@ -191,7 +189,6 @@ router.get('/encounters', async (req, res) => {
       body: JSON.stringify({ Query }),
     })
 
-    console.log(encounters)
     const jsonEncounters = await encounters.json()
 
     const raidOnlyEncounters =
@@ -199,9 +196,13 @@ router.get('/encounters', async (req, res) => {
         (zone: { name: string | string[] }) =>
           !zone.name.includes('Mythic+') && !zone.name.includes('zone-')
       )
-    console.log(raidOnlyEncounters)
 
-    res.json(raidOnlyEncounters)
+    const currentEncounters = await raidOnlyEncounters.flatMap(
+      (encounter: { encounters: { name: string; id: number } }) =>
+        encounter.encounters
+    )
+
+    res.json(currentEncounters)
   } catch (error) {
     console.log(error)
     res.status(500).json({ message: 'Something went wrong' })

--- a/server/routes/queries/queries.ts
+++ b/server/routes/queries/queries.ts
@@ -11,6 +11,7 @@ const queryEncounterIDs = () => `query {
 	worldData {
 		expansion (id: 5)  {
 			zones {
+				name
 				encounters {
 					name
 					id


### PR DESCRIPTION
Additional Features
- UE improved, the select field for encounters now self populates with the current raid tiers bosses.
- Improved layout for better navigation
- Server Text input now has validation and sanitation for accurate translation of literal server names to server slugs

Note
- Select field for server no longer being implemented, would require multiple api calls to work around pagination of wowlogs api, potentially going to download server list and simply keep it within our database.